### PR TITLE
feat: adiciona validador de título das PR

### DIFF
--- a/.github/workflows/lint-pr-titulo.yml
+++ b/.github/workflows/lint-pr-titulo.yml
@@ -1,0 +1,15 @@
+name: Lint PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  main:
+    name: Valida título da PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR com o objetivo de adicionar pipeline que valida se o título da PR segue o [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), afim de dar maior padrão ao nosso código.